### PR TITLE
Add ability to disable StripWhiteSpaces at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ all the credit goes for [this post](http://stackoverflow.com/questions/356126/ho
 
 I'm only put it in a way of vim plugin
 
+Disabling
+-
+
+To disable it globally place the following in your `.vimrc`:
+
+    let g:loaded_StripWhiteSpaces = 1
+
+To disable it for just the current buffer set the following anywhere it makes sense (e.g. within a ftplugin file if you don't want to touch trailing whitespace for a certain file type):
+
+    let b:disable_StripWhiteSpaces = 1
+
+If you just wanted to do that temporarily you can either set `b:disable_StripWhiteSpaces = 0` or `unlet b:disable_StripWhiteSpaces` and it will strip white spaces once again.
+
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/gagoar/stripwhitespaces/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 

--- a/plugin/StripWhiteSpaces.vim
+++ b/plugin/StripWhiteSpaces.vim
@@ -1,4 +1,12 @@
+if exists('g:loaded_StripWhiteSpaces') || &cp
+    finish
+endif
+let g:loaded_StripWhiteSpaces = 1
+
 function! s:StripWhiteSpaces()
+    if exists('b:disable_StripWhiteSpaces') && b:disable_StripWhiteSpaces
+        return
+    endif
     let save_cursor = getpos(".")
     let old_query = getreg('/')
     :%s/\s\+$//e


### PR DESCRIPTION
Basically I wanted a way to disable StripWhiteSpaces from running if I need to keep the white space in there for whatever reason.  Now if `b:disable_StripWhiteSpaces` exists and evaluates to true it won't strip white space.  The `g:loaded_StripWhiteSpaces` is just a common plugin convention.
