### PR TITLE
Use undojoin to prevent problems with auto save

### DIFF
--- a/plugin/StripWhiteSpaces.vim
+++ b/plugin/StripWhiteSpaces.vim
@@ -9,9 +9,11 @@ function! s:StripWhiteSpaces()
     endif
     let save_cursor = getpos(".")
     let old_query = getreg('/')
+    undojoin
     :%s/\s\+$//e
 
     if exists('g:strip_trailing_lines') && g:strip_trailing_lines
+        undojoin
         :%s#\($\n\s*\)\+\%$##e
     endif
 


### PR DESCRIPTION
Each `:%s...` command creates an undo entry. This isn't a huge deal unless you're running a plugin that automatically saves. In that case, if you have extra whitespace and you save, if you hit `u` to undo, it'll undo the whitespace trim, then immediately auto save, causing the whitespace to go away, meaning you need to undo again to get past that loop. 

This prevents that by joining the whitespace and newline trims to the previous command which is usually an OK thing.